### PR TITLE
Fix dangling GOConfig reference in GOCommonControllerTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed crash on unknown command-line argument
 - Fixed on-screen keyboard appearing when tapping organ panels on touch-enabled desktops https://github.com/GrandOrgue/grandorgue/issues/2492
 - Removed default keyboard shortcut assignments from MIDI objects; shortcuts must now be assigned manually in the MIDI event dialog
 - Fixed expression pedal malfunction when CC value exceeds configured high value https://github.com/GrandOrgue/grandorgue/issues/2494

--- a/build-scripts/for-osx/prepare-osx.sh
+++ b/build-scripts/for-osx/prepare-osx.sh
@@ -9,6 +9,7 @@ brew link --overwrite pkg-config
 cmake --version || brew install cmake
 
 brew install \
+  berkeley-db@5 \
   docbook \
   docbook-xsl \
   fftw wavpack \

--- a/src/grandorgue/GOOrganController.cpp
+++ b/src/grandorgue/GOOrganController.cpp
@@ -99,7 +99,7 @@ GOOrganController::GOOrganController(GOConfig &config, bool isAppInitialized)
     mp_ImageCache(nullptr),
     m_PitchLabel(*this),
     m_TemperamentLabel(*this),
-    m_MainWindowData(this, wxT("MainWindow")) {
+    m_MainWindowData(*this, wxT("MainWindow")) {
   if (isAppInitialized) {
     // Load here objects that needs App (wx) to be loaded
     m_timer = new GOTimer();

--- a/src/grandorgue/GOOrganController.h
+++ b/src/grandorgue/GOOrganController.h
@@ -104,7 +104,6 @@ private:
   GOGUIMouseState m_MouseState;
 
   GOMemoryPool m_pool;
-  GOSoundOrganEngine m_SoundEngine;
   GOGuiImageCache *mp_ImageCache;
   GOLabelControl m_PitchLabel;
   GOLabelControl m_TemperamentLabel;

--- a/src/grandorgue/gui/GOGuiApp.cpp
+++ b/src/grandorgue/gui/GOGuiApp.cpp
@@ -36,8 +36,19 @@ IMPLEMENT_APP(GOGuiApp)
 
 GOGuiApp::~GOGuiApp() = default;
 
-void GOGuiApp::TemporaryLog::DoLogTextAtLevel(
-  wxLogLevel level, const wxString &msg) {
+/**
+ * A temporary logging class.
+ * It logs all Warning and Error log messages to stderr, all other messages to
+ * stdout. It also displays all Error messages to a modal message box.
+ * It is used only before initializing the GOGuiLog instance, including during
+ * reading the GrandOrgueConfig
+ */
+class TemporaryLog : public wxLog {
+protected:
+  void DoLogTextAtLevel(wxLogLevel level, const wxString &msg) override;
+};
+
+void TemporaryLog::DoLogTextAtLevel(wxLogLevel level, const wxString &msg) {
   FILE *output = (level <= wxLOG_Warning) ? stderr : stdout;
 
   fprintf(output, "%s\n", msg.mb_str().data());
@@ -120,7 +131,9 @@ bool GOGuiApp::OnCmdLineParsed(wxCmdLineParser &parser) {
 }
 
 bool GOGuiApp::OnInit() {
-  wxLog::SetActiveTarget(mp_TemporaryLog.get());
+  // Ownership is transferred to wxWidgets: wxEntryCleanup() calls the deleting
+  // destructor on the active log target, so we must not delete it ourselves.
+  wxLog::SetActiveTarget(new TemporaryLog());
 
 #ifdef __WXMAC__
   /* This ensures that the executable (when it is not in the form of an OS X
@@ -174,7 +187,10 @@ bool GOGuiApp::OnInit() {
     *mp_SoundSystem);
   SetTopWindow(p_AppWindow);
   mp_log = std::make_unique<GOGuiLog>(p_AppWindow);
-  wxLog::SetActiveTarget(mp_log.get());
+  // SetActiveTarget returns the previous logger (TemporaryLog, released from
+  // mp_TemporaryLog), which wxWidgets won't delete because it's no longer
+  // active. Delete it explicitly now that we are done with it.
+  delete wxLog::SetActiveTarget(mp_log.get());
   p_AppWindow->Init(m_FileName, m_IsGuiOnly);
 
   return true;

--- a/src/grandorgue/gui/GOGuiApp.h
+++ b/src/grandorgue/gui/GOGuiApp.h
@@ -33,21 +33,6 @@ class GOSoundSystem;
 
 class GOGuiApp : public wxApp {
 private:
-  /**
-   * A temporary logging class.
-   * It logs all Warning and Error log messages to stderr, all other messages to
-   * stdout. It alse displays all Error messages to a modal message box.
-   * It is used only before initialising the GOGuiLog instance, including during
-   * reading the GrandOrgueConfig
-   */
-  class TemporaryLog : public wxLog {
-  protected:
-    void DoLogTextAtLevel(wxLogLevel level, const wxString &msg) override;
-  };
-
-  // A temporary logging instance
-  std::unique_ptr<TemporaryLog> mp_TemporaryLog
-    = std::make_unique<TemporaryLog>();
   bool m_IsToRestartAfterExit = false;
 
 #ifdef __WXMAC__

--- a/src/grandorgue/gui/GOGuiOrgan.cpp
+++ b/src/grandorgue/gui/GOGuiOrgan.cpp
@@ -66,8 +66,6 @@ GOOrganController *GOGuiOrgan::LoadOrgan(
       wxCommandEvent event(wxEVT_SETVALUE, ID_METER_AUDIO_SPIN);
       event.SetInt(m_OrganController->GetVolume());
       wxTheApp->GetTopWindow()->GetEventHandler()->AddPendingEvent(event);
-
-      m_sound.GetEngine().SetVolume(m_OrganController->GetVolume());
     }
 
     wxCommandEvent event(wxEVT_WINTITLE, 0);
@@ -85,6 +83,7 @@ GOOrganController *GOGuiOrgan::LoadOrgan(
       p_MainWindow->SetPosSize(mRect);
 
     m_sound.AssignOrganFile(m_OrganController);
+    m_sound.GetEngine().SetVolume(m_OrganController->GetVolume());
     m_OrganFileReady = true;
     m_listener.SetCallback(this);
     if (!cmb.IsEmpty())

--- a/src/grandorgue/gui/frames/GOMainWindowData.cpp
+++ b/src/grandorgue/gui/frames/GOMainWindowData.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2023 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -10,10 +10,10 @@
 #include "config/GOConfigReader.h"
 #include "config/GOConfigWriter.h"
 
-#include "GOOrganController.h"
+#include "model/GOOrganModel.h"
 
 void GOMainWindowData::Load(GOConfigReader &cfg) {
-  p_organFile->RegisterSaveableObject(this);
+  r_OrganModel.RegisterSaveableObject(this);
   m_rect.x = cfg.ReadInteger(
     CMBSetting, m_group, wxT("WindowX"), -20, 10000, false, 0);
   m_rect.y = cfg.ReadInteger(

--- a/src/grandorgue/gui/frames/GOMainWindowData.h
+++ b/src/grandorgue/gui/frames/GOMainWindowData.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2006 Milan Digital Audio LLC
- * Copyright 2009-2024 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2009-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -14,16 +14,16 @@
 
 #include "GOSaveableObject.h"
 
-class GOOrganController;
+class GOOrganModel;
 
 class GOMainWindowData : private GOSaveableObject {
 protected:
-  GOOrganController *p_organFile;
+  GOOrganModel &r_OrganModel;
   GOLogicalRect m_rect;
 
 public:
-  GOMainWindowData(GOOrganController *pOrganFile, const wxString &group)
-    : p_organFile(pOrganFile) {
+  GOMainWindowData(GOOrganModel &organModel, const wxString &group)
+    : r_OrganModel(organModel) {
     m_group = group;
   }
   virtual ~GOMainWindowData() {}

--- a/src/grandorgue/sound/GOSoundOrganEngine.cpp
+++ b/src/grandorgue/sound/GOSoundOrganEngine.cpp
@@ -29,42 +29,115 @@
 #include "GOEvent.h"
 #include "GOSoundRecorder.h"
 
-GOSoundOrganEngine::GOSoundOrganEngine()
-  : m_PolyphonyLimiting(true),
-    m_ScaledReleases(true),
-    m_ReleaseAlignmentEnabled(true),
-    m_RandomizeSpeaking(true),
-    m_Volume(-15),
-    m_SamplesPerBuffer(1),
-    m_Gain(1),
+/*
+ * Factory functions
+ */
+
+std::vector<GOSoundOrganEngine::AudioOutputConfig> GOSoundOrganEngine::
+  createAudioOutputConfigs(GOConfig &config, unsigned nAudioGroups) {
+  std::vector<GOAudioDeviceConfig> &audioDeviceConfig
+    = config.GetAudioDeviceConfig();
+  const unsigned nDevices = audioDeviceConfig.size();
+
+  std::vector<AudioOutputConfig> result(nDevices);
+
+  for (unsigned deviceI = 0; deviceI < nDevices; deviceI++) {
+    const GOAudioDeviceConfig &deviceConfig = audioDeviceConfig[deviceI];
+    const auto &deviceOutputs = deviceConfig.GetChannelOututs();
+    AudioOutputConfig &outConfig = result[deviceI];
+
+    outConfig.channels = deviceConfig.GetChannels();
+    outConfig.scaleFactors.resize(outConfig.channels);
+
+    for (unsigned channelI = 0; channelI < outConfig.channels; channelI++) {
+      std::vector<float> &scaleFactors = outConfig.scaleFactors[channelI];
+
+      scaleFactors.resize(nAudioGroups * 2);
+      std::fill(
+        scaleFactors.begin(),
+        scaleFactors.end(),
+        GOAudioDeviceConfig::MUTE_VOLUME);
+
+      if (channelI < deviceOutputs.size()) {
+        for (const auto &groupOutput : deviceOutputs[channelI]) {
+          int id = config.GetStrictAudioGroupId(groupOutput.GetName());
+
+          if (id >= 0) {
+            scaleFactors[id * 2] = groupOutput.GetLeft();
+            scaleFactors[id * 2 + 1] = groupOutput.GetRight();
+          }
+        }
+      }
+    }
+  }
+  return result;
+}
+
+std::vector<GOSoundOrganEngine::AudioOutputConfig> GOSoundOrganEngine::
+  createDefaultOutputConfigs(unsigned nAudioGroups) {
+  AudioOutputConfig config;
+
+  config.channels = 2;
+  config.scaleFactors.resize(2);
+  config.scaleFactors[0].resize(
+    nAudioGroups * 2, GOAudioDeviceConfig::MUTE_VOLUME);
+  config.scaleFactors[1].resize(
+    nAudioGroups * 2, GOAudioDeviceConfig::MUTE_VOLUME);
+
+  for (unsigned groupI = 0; groupI < nAudioGroups; groupI++) {
+    config.scaleFactors[0][groupI * 2] = 0.0f;
+    config.scaleFactors[1][groupI * 2 + 1] = 0.0f;
+  }
+  return {config};
+}
+
+/*
+ * Constructors and destructors
+ */
+
+GOSoundOrganEngine::GOSoundOrganEngine(
+  GOOrganModel &organModel, GOMemoryPool &memoryPool)
+  : r_OrganModel(organModel),
+    r_MemoryPool(memoryPool),
+    mp_ReleaseTask(
+      std::make_unique<GOSoundReleaseTask>(*this, mp_AudioGroupTasks)),
+    mp_TouchTask(std::make_unique<GOSoundTouchTask>(r_MemoryPool)),
+    m_NAudioGroups(1),
+    m_NAuxThreads(0),
+    m_IsDownmix(false),
+    m_NReleaseRepeats(1),
+    m_IsPolyphonyLimiting(true),
+    m_PolyphonySoftLimit(0),
+    m_IsScaledReleases(true),
+    m_IsReleaseAlignmentEnabled(true),
+    m_IsRandomizeSpeaking(true),
+    m_InterpolationType(GOSoundResample::GO_LINEAR_INTERPOLATION),
+    m_ReverbConfig(GOSoundReverb::CONFIG_REVERB_DISABLED),
+    m_NSamplesPerBuffer(1),
     m_SampleRate(0),
+    m_LifecycleState(LifecycleState::IDLE),
+    p_AudioRecorder(nullptr),
     m_CurrentTime(1),
-    m_SamplerPool(),
-    m_AudioGroupCount(1),
-    m_UsedPolyphony(0),
-    mp_MeterInfo(std::make_unique<std::vector<std::atomic<float>>>(0)),
-    p_MeterInfo(mp_MeterInfo.get()),
-    m_TremulantTasks(),
-    m_WindchestTasks(),
-    m_AudioGroupTasks(),
-    m_AudioOutputTasks(),
-    m_AudioRecorder(NULL),
-    m_TouchTask(),
-    m_HasBeenSetup(false) {
+    m_UsedPolyphony(0) {
+  SetVolume(-15);
   m_SamplerPool.SetUsageLimit(2048);
   m_PolyphonySoftLimit = (m_SamplerPool.GetUsageLimit() * 3) / 4;
-  m_ReleaseProcessor = new GOSoundReleaseTask(*this, m_AudioGroupTasks);
-  Reset();
 }
 
-GOSoundOrganEngine::~GOSoundOrganEngine() {
-  if (m_ReleaseProcessor)
-    delete m_ReleaseProcessor;
-}
+// The destructor body is empty, but it must be defined here (not in the header)
+// so that std::unique_ptr can call the complete destructors of its managed
+// types (GOSoundReleaseTask, GOSoundTouchTask, GOSoundThread), which are only
+// forward-declared in the header file.
+GOSoundOrganEngine::~GOSoundOrganEngine() {}
 
+/*
+ * Configuration getters and setters
+ */
+
+// TODO: rename to SetGain(int gain), m_volume → m_gain, m_gain → m_amplitude
 void GOSoundOrganEngine::SetVolume(int volume) {
-  m_Volume = volume;
-  m_Gain = powf(10.0f, m_Volume * 0.05f);
+  m_volume = volume;
+  m_gain = powf(10.0f, m_volume * 0.05f);
 }
 
 void GOSoundOrganEngine::SetHardPolyphony(unsigned polyphony) {
@@ -72,205 +145,344 @@ void GOSoundOrganEngine::SetHardPolyphony(unsigned polyphony) {
   m_PolyphonySoftLimit = (m_SamplerPool.GetUsageLimit() * 3) / 4;
 }
 
-void GOSoundOrganEngine::SetAudioGroupCount(unsigned groups) {
-  if (groups < 1)
-    groups = 1;
-  m_AudioGroupCount = groups;
-  m_AudioGroupTasks.clear();
-  for (unsigned i = 0; i < m_AudioGroupCount; i++)
-    m_AudioGroupTasks.push_back(
-      new GOSoundGroupTask(*this, m_SamplesPerBuffer));
+void GOSoundOrganEngine::SetFromConfig(GOConfig &config) {
+  const unsigned nAudioGroups = config.GetAudioGroups().size();
+
+  SetNAudioGroups(nAudioGroups >= 1 ? nAudioGroups : 1);
+  SetNAuxThreads(config.Concurrency());
+  SetDownmix(config.RecordDownmix());
+  SetNReleaseRepeats(config.ReleaseConcurrency());
+  SetPolyphonyLimiting(config.ManagePolyphony());
+  SetHardPolyphony(config.PolyphonyLimit());
+  SetScaledReleases(config.ScaleRelease());
+  SetRandomizeSpeaking(config.RandomizeSpeaking());
+  SetInterpolationType(config.m_InterpolationType());
+  SetReverbConfig(GOSoundReverb::createReverbConfig(config));
 }
 
-void GOSoundOrganEngine::SetAudioOutput(
-  std::vector<GOAudioOutputConfiguration> audio_outputs) {
-  m_AudioOutputTasks.clear();
-  {
-    std::vector<float> scale_factors;
-    scale_factors.resize(m_AudioGroupCount * 2 * 2);
-    std::fill(scale_factors.begin(), scale_factors.end(), 0.0f);
-    for (unsigned i = 0; i < m_AudioGroupCount; i++) {
-      scale_factors[i * 4] = 1;
-      scale_factors[i * 4 + 3] = 1;
-    }
-    m_AudioOutputTasks.push_back(
-      new GOSoundOutputTask(2, scale_factors, m_SamplesPerBuffer));
+/*
+ * Lifecycle functions
+ */
+
+void GOSoundOrganEngine::BuildEngine(
+  const std::vector<AudioOutputConfig> &audioOutputConfigs,
+  unsigned nSamplesPerBuffer,
+  unsigned sampleRate,
+  GOSoundRecorder &recorder) {
+  GOMutexLocker locker(m_LifecycleMutex);
+
+  assert(m_LifecycleState.load() == LifecycleState::IDLE);
+
+  m_NSamplesPerBuffer = nSamplesPerBuffer;
+  m_SampleRate = sampleRate;
+  p_AudioRecorder = &recorder;
+
+  // [B1] Build audio group tasks
+  std::vector<GOSoundBufferTaskBase *> groupOutputs;
+
+  for (unsigned groupI = 0; groupI < m_NAudioGroups; groupI++) {
+    GOSoundGroupTask *pGroupTask
+      = new GOSoundGroupTask(*this, m_NSamplesPerBuffer);
+
+    mp_AudioGroupTasks.push_back(pGroupTask);
+    groupOutputs.push_back(pGroupTask);
   }
-  unsigned channels = 0;
-  for (unsigned i = 0; i < audio_outputs.size(); i++) {
-    std::vector<float> scale_factors;
-    scale_factors.resize(m_AudioGroupCount * audio_outputs[i].channels * 2);
-    std::fill(scale_factors.begin(), scale_factors.end(), 0.0f);
-    for (unsigned j = 0; j < audio_outputs[i].channels; j++)
-      for (unsigned k = 0; k < audio_outputs[i].scale_factors[j].size(); k++) {
-        if (k >= m_AudioGroupCount * 2)
-          continue;
-        float factor = audio_outputs[i].scale_factors[j][k];
+
+  // [B2] Build audio output tasks (per-device only)
+  unsigned nTotalChannels = 0;
+
+  for (unsigned deviceI = 0; deviceI < audioOutputConfigs.size(); deviceI++) {
+    const AudioOutputConfig &devConfig = audioOutputConfigs[deviceI];
+    const unsigned nChannels = devConfig.channels;
+    std::vector<float> scaleFactors;
+
+    scaleFactors.resize(m_NAudioGroups * nChannels * 2);
+    std::fill(scaleFactors.begin(), scaleFactors.end(), 0.0f);
+    for (unsigned channelI = 0; channelI < nChannels; channelI++) {
+      for (unsigned k = 0; k < devConfig.scaleFactors[channelI].size(); k++) {
+        if (k >= m_NAudioGroups * 2)
+          break;
+        float factor = devConfig.scaleFactors[channelI][k];
         if (factor >= -120 && factor < 40)
           factor = powf(10.0f, factor * 0.05f);
         else
           factor = 0;
-        scale_factors[j * m_AudioGroupCount * 2 + k] = factor;
+        scaleFactors[channelI * m_NAudioGroups * 2 + k] = factor;
       }
-    m_AudioOutputTasks.push_back(new GOSoundOutputTask(
-      audio_outputs[i].channels, scale_factors, m_SamplesPerBuffer));
-    channels += audio_outputs[i].channels;
-  }
-  std::vector<GOSoundBufferTaskBase *> outputs;
-  for (unsigned i = 0; i < m_AudioGroupTasks.size(); i++)
-    outputs.push_back(m_AudioGroupTasks[i]);
-  for (unsigned i = 0; i < m_AudioOutputTasks.size(); i++)
-    m_AudioOutputTasks[i]->SetOutputs(outputs);
-  {
-    // Control thread: prevent GetMeterInfo() from reading the buffer while it
-    // is being replaced. SetAudioOutput() is called only when all audio
-    // callbacks are stopped (between StopSoundSystem and StartSoundSystem),
-    // so the audio thread is not accessing p_MeterInfo concurrently.
-    GOMutexLocker locker(m_MeterMutex);
-
-    if (mp_MeterInfo->size() != channels) {
-      auto newInfo
-        = std::make_unique<std::vector<std::atomic<float>>>(channels);
-
-      // Prior to C++20, std::atomic default construction does not
-      // zero-initialize the value; initialize explicitly for safety.
-      for (auto &v : *newInfo)
-        v.store(0.0f, std::memory_order_relaxed);
-
-      // Store the new pointer before destroying the old vector so that
-      // p_MeterInfo always points to a valid object.
-      // release: the audio thread will see the new vector (size + data) via
-      // acquire-load of p_MeterInfo on the next NextPeriod() call.
-      p_MeterInfo.store(newInfo.get(), std::memory_order_release);
-      mp_MeterInfo = std::move(newInfo);
     }
-  }
-}
-
-void GOSoundOrganEngine::SetupReverb(GOConfig &settings) {
-  const GOSoundReverb::ReverbConfig reverbConfig
-    = GOSoundReverb::createReverbConfig(settings);
-
-  for (unsigned i = 0; i < m_AudioOutputTasks.size(); i++)
-    if (m_AudioOutputTasks[i])
-      m_AudioOutputTasks[i]->SetupReverb(
-        reverbConfig, settings.SamplesPerBuffer(), settings.SampleRate());
-}
-
-void GOSoundOrganEngine::SetAudioRecorder(
-  GOSoundRecorder *recorder, bool downmix) {
-  m_AudioRecorder = recorder;
-  std::vector<GOSoundBufferTaskBase *> outputs;
-  if (downmix)
-    outputs.push_back(m_AudioOutputTasks[0]);
-  else {
-    m_Scheduler.Remove(m_AudioOutputTasks[0]);
-    delete m_AudioOutputTasks[0];
-    m_AudioOutputTasks[0] = NULL;
-    for (unsigned i = 1; i < m_AudioOutputTasks.size(); i++)
-      outputs.push_back(m_AudioOutputTasks[i]);
-  }
-  m_AudioRecorder->SetOutputs(outputs, m_SamplesPerBuffer);
-}
-
-std::vector<float> GOSoundOrganEngine::GetMeterInfo() {
-  // GUI thread: m_MeterMutex prevents concurrent replacement by SetAudioOutput
-  GOMutexLocker locker(m_MeterMutex);
-  std::vector<std::atomic<float>> &info = *p_MeterInfo.load();
-  const unsigned hardPolyphony = GetHardPolyphony();
-  std::vector<float> result(info.size() + 1);
-  float *pResult = result.data();
-
-  assert(hardPolyphony > 0);
-  // exchange(0) reads accumulated max and resets it for the next poll
-  *(pResult++)
-    = m_UsedPolyphony.exchange(0) / static_cast<float>(hardPolyphony);
-  for (std::atomic<float> &v : info)
-    *(pResult++) = v.exchange(0.0f);
-  return result;
-}
-
-void GOSoundOrganEngine::Reset() {
-  if (m_HasBeenSetup.load()) {
-    for (unsigned i = 0; i < m_WindchestTasks.size(); i++)
-      m_WindchestTasks[i]->Init(m_TremulantTasks);
+    mp_AudioOutputTasks.push_back(std::make_unique<GOSoundOutputTask>(
+      nChannels, scaleFactors, m_NSamplesPerBuffer));
+    mp_AudioOutputTasks.back()->SetOutputs(groupOutputs);
+    nTotalChannels += nChannels;
   }
 
+  // [B3] Resize meter info to match real output channels.
+  // std::atomic is not copyable/movable, so we construct a fresh vector and
+  // swap instead of resize.
+  {
+    std::vector<std::atomic<float>> newMeterInfo(nTotalChannels);
+
+    m_MeterInfo.swap(newMeterInfo);
+  }
+
+  // [B4] Build downmix task (optional stereo mix for recorder)
+  if (m_IsDownmix) {
+    std::vector<float> scaleFactors;
+
+    scaleFactors.resize(m_NAudioGroups * 2 * 2);
+    std::fill(scaleFactors.begin(), scaleFactors.end(), 0.0f);
+    for (unsigned groupI = 0; groupI < m_NAudioGroups; groupI++) {
+      scaleFactors[groupI * 4] = 1;
+      scaleFactors[groupI * 4 + 3] = 1;
+    }
+    mp_DownmixTask = std::make_unique<GOSoundOutputTask>(
+      2, scaleFactors, m_NSamplesPerBuffer);
+    mp_DownmixTask->SetOutputs(groupOutputs);
+  }
+
+  // [B5] Set up recorder outputs
+  {
+    std::vector<GOSoundBufferTaskBase *> recorderOutputs;
+
+    if (mp_DownmixTask)
+      recorderOutputs.push_back(mp_DownmixTask.get());
+    else
+      for (auto &pTask : mp_AudioOutputTasks)
+        recorderOutputs.push_back(pTask.get());
+    p_AudioRecorder->SetOutputs(recorderOutputs, m_NSamplesPerBuffer);
+  }
+
+  // [B6] Set up reverb
+  if (mp_DownmixTask)
+    mp_DownmixTask->SetupReverb(
+      m_ReverbConfig, m_NSamplesPerBuffer, m_SampleRate);
+  for (auto &pTask : mp_AudioOutputTasks)
+    pTask->SetupReverb(m_ReverbConfig, m_NSamplesPerBuffer, m_SampleRate);
+
+  // [B7] Build tremulant tasks
+  for (unsigned n = r_OrganModel.GetTremulantCount(), tremI = 0; tremI < n;
+       tremI++)
+    mp_TremulantTasks.push_back(
+      new GOSoundTremulantTask(*this, m_NSamplesPerBuffer));
+
+  // [B8] Build windchest tasks
+  // Special windchest task for detached releases (index 0 =
+  // DETACHED_RELEASE_TASK_ID)
+  mp_WindchestTasks.push_back(
+    std::make_unique<GOSoundWindchestTask>(*this, nullptr));
+  for (unsigned n = r_OrganModel.GetWindchestCount(), wcI = 0; wcI < n; wcI++)
+    mp_WindchestTasks.push_back(std::make_unique<GOSoundWindchestTask>(
+      *this, r_OrganModel.GetWindchest(wcI)));
+
+  // [B9] Initialize windchests with tremulant tasks
+  for (auto &pWcTask : mp_WindchestTasks)
+    pWcTask->Init(mp_TremulantTasks);
+
+  // [B10] Add all tasks to scheduler
+  m_Scheduler.Clear();
+  m_Scheduler.SetRepeatCount(m_NReleaseRepeats);
+  for (GOSoundTremulantTask *pTremTask : mp_TremulantTasks)
+    m_Scheduler.Add(pTremTask);
+  for (auto &pWcTask : mp_WindchestTasks)
+    m_Scheduler.Add(pWcTask.get());
+  for (GOSoundGroupTask *pGroupTask : mp_AudioGroupTasks)
+    m_Scheduler.Add(pGroupTask);
+  if (mp_DownmixTask)
+    m_Scheduler.Add(mp_DownmixTask.get());
+  for (auto &pOutputTask : mp_AudioOutputTasks)
+    m_Scheduler.Add(pOutputTask.get());
+  m_Scheduler.Add(p_AudioRecorder);
+  m_Scheduler.Add(mp_ReleaseTask.get());
+  m_Scheduler.Add(mp_TouchTask.get());
+
+  // [B11] Build worker threads
+  for (unsigned threadI = 0; threadI < m_NAuxThreads; threadI++)
+    mp_threads.push_back(std::make_unique<GOSoundThread>(&m_Scheduler));
+  for (auto &pThread : mp_threads)
+    pThread->Run();
+
+  m_LifecycleState.store(LifecycleState::BUILT);
+}
+
+void GOSoundOrganEngine::DestroyEngine() {
+  GOMutexLocker locker(m_LifecycleMutex);
+
+  assert(m_LifecycleState.load() == LifecycleState::BUILT);
+
+  // [B11] Destroy worker threads
+  for (auto &pThread : mp_threads)
+    pThread->Delete();
+  mp_threads.clear();
+
+  // [B10] Clear scheduler
   m_Scheduler.Clear();
 
-  if (m_HasBeenSetup.load()) {
-    for (unsigned i = 0; i < m_TremulantTasks.size(); i++)
-      m_Scheduler.Add(m_TremulantTasks[i]);
-    for (unsigned i = 0; i < m_WindchestTasks.size(); i++)
-      m_Scheduler.Add(m_WindchestTasks[i]);
-    for (unsigned i = 0; i < m_AudioGroupTasks.size(); i++)
-      m_Scheduler.Add(m_AudioGroupTasks[i]);
-    for (unsigned i = 0; i < m_AudioOutputTasks.size(); i++)
-      m_Scheduler.Add(m_AudioOutputTasks[i]);
-    m_Scheduler.Add(m_AudioRecorder);
-    m_Scheduler.Add(m_ReleaseProcessor);
-    if (m_TouchTask)
-      m_Scheduler.Add(m_TouchTask.get());
-  }
+  // [B9] + [B8] Destroy windchest tasks (drops Init() connections too)
+  mp_WindchestTasks.clear();
+
+  // [B7] Destroy tremulant tasks
+  mp_TremulantTasks.clear();
+
+  // [B6] Reverb — no explicit cleanup (owned by output tasks below)
+  // [B5] Recorder outputs — no explicit cleanup (recorder is non-owning)
+
+  // [B4] Destroy downmix task
+  mp_DownmixTask.reset();
+
+  // [B3] Clear meter info
+  m_MeterInfo.clear();
+
+  // [B2] Destroy audio output tasks
+  mp_AudioOutputTasks.clear();
+
+  // [B1] Destroy audio group tasks
+  for (GOSoundGroupTask *pGroupTask : mp_AudioGroupTasks)
+    pGroupTask->WaitAndClear();
+  mp_AudioGroupTasks.clear();
+
+  m_LifecycleState.store(LifecycleState::IDLE);
+}
+
+void GOSoundOrganEngine::ResetCounters() {
   m_UsedPolyphony.store(0);
   m_SamplerPool.ReturnAll();
   m_CurrentTime = 1;
   m_Scheduler.Reset();
 }
 
-void GOSoundOrganEngine::Setup(
-  GOOrganModel &organModel, GOMemoryPool &memoryPool, unsigned releaseCount) {
-  m_Scheduler.Clear();
-  if (releaseCount < 1)
-    releaseCount = 1;
-  m_Scheduler.SetRepeatCount(releaseCount);
-  m_TremulantTasks.clear();
-  for (unsigned i = 0; i < organModel.GetTremulantCount(); i++)
-    m_TremulantTasks.push_back(
-      new GOSoundTremulantTask(*this, m_SamplesPerBuffer));
-  m_WindchestTasks.clear();
-  // a special windchest task for detached releases
-  m_WindchestTasks.push_back(new GOSoundWindchestTask(*this, NULL));
-  for (unsigned i = 0; i < organModel.GetWindchestCount(); i++)
-    m_WindchestTasks.push_back(
-      new GOSoundWindchestTask(*this, organModel.GetWindchest(i)));
-  m_TouchTask
-    = std::unique_ptr<GOSoundTouchTask>(new GOSoundTouchTask(memoryPool));
-  m_HasBeenSetup.store(true);
-  Reset();
+void GOSoundOrganEngine::StartEngine() {
+  assert(m_LifecycleState.load() == LifecycleState::BUILT);
+  ResetCounters();
+  m_Scheduler.ResumeGivingWork();
+  m_LifecycleState.store(LifecycleState::WORKING);
 }
 
-void GOSoundOrganEngine::ClearSetup() {
-  m_HasBeenSetup.store(false);
+void GOSoundOrganEngine::StopEngine() {
+  assert(m_LifecycleState.load() == LifecycleState::WORKING);
+  m_Scheduler.PauseGivingWork();
+  for (auto &pThread : mp_threads)
+    pThread->WaitForIdle();
+  m_LifecycleState.store(LifecycleState::BUILT);
+}
 
-  // the winchests may be still used from audio callbacks.
-  // clear the pending sound before destroying the windchests
-  for (unsigned i = 0; i < m_AudioGroupTasks.size(); i++)
-    m_AudioGroupTasks[i]->WaitAndClear();
+void GOSoundOrganEngine::BuildAndStart(
+  const std::vector<AudioOutputConfig> &audioOutputConfigs,
+  unsigned nSamplesPerBuffer,
+  unsigned sampleRate,
+  GOSoundRecorder &recorder) {
+  BuildEngine(audioOutputConfigs, nSamplesPerBuffer, sampleRate, recorder);
+  StartEngine();
+}
 
-  m_Scheduler.Clear();
-  m_WindchestTasks.clear();
-  m_TremulantTasks.clear();
-  m_TouchTask = NULL;
-  Reset();
+void GOSoundOrganEngine::StopAndDestroy() {
+  StopEngine();
+  DestroyEngine();
+}
+
+void GOSoundOrganEngine::SetUsed(bool isUsed) {
+  const LifecycleState oldState = m_LifecycleState.load();
+
+  assert(
+    oldState >= LifecycleState::WORKING && oldState <= LifecycleState::USED);
+  (void)oldState; // suppress unused-variable warning in Release (assert is
+                  // compiled out)
+
+  m_LifecycleState.store(
+    isUsed ? LifecycleState::USED : LifecycleState::WORKING);
+}
+
+/*
+ * Functions called from GOSoundSystem
+ */
+
+void GOSoundOrganEngine::GetAudioOutput(
+  unsigned outputIndex, bool isLast, GOSoundBufferMutable &outBuffer) {
+  if (IsWorking()) {
+    GOSoundOutputTask *pOutputTask = mp_AudioOutputTasks[outputIndex].get();
+
+    pOutputTask->Finish(isLast);
+    outBuffer.CopyFrom(*pOutputTask);
+  } else
+    outBuffer.FillWithSilence();
+}
+
+/**
+ * Atomically updates maxValue to max(maxValue, value) with relaxed ordering.
+ * std::atomic<T>::fetch_max is only available in C++26.
+ */
+template <typename T>
+static void atomic_fetch_max_relaxed(std::atomic<T> &maxValue, T value) {
+  T oldMax = maxValue.load(std::memory_order_relaxed);
+
+  while (oldMax < value
+         && !maxValue.compare_exchange_weak(
+           oldMax, value, std::memory_order_relaxed))
+    ;
+}
+
+void GOSoundOrganEngine::NextPeriod() {
+  assert(IsWorking());
+  m_Scheduler.Exec();
+
+  m_CurrentTime += m_NSamplesPerBuffer;
+  atomic_fetch_max_relaxed(m_UsedPolyphony, m_SamplerPool.UsedSamplerCount());
+
+  // Accumulate per-channel peak levels from each output task into m_MeterInfo
+  // for the GUI meter display. Values accumulate between GUI polls;
+  // GetMeterInfo() resets them via exchange(0). Only real device outputs
+  // (mp_AudioOutputTasks) are counted; mp_DownmixTask is excluded.
+  // Guarded by assert(IsWorking()) above: m_MeterInfo is valid in WORKING
+  // state.
+  const auto meterEnd = m_MeterInfo.end();
+  auto meterIt = m_MeterInfo.begin();
+
+  for (auto &pTask : mp_AudioOutputTasks) {
+    for (const float f : pTask->GetMeterInfo()) {
+      // m_MeterInfo.size() == nTotalChannels [B3] == sum of channels across
+      // all mp_AudioOutputTasks [B2], so the iterator never overflows.
+      assert(meterIt < meterEnd);
+      atomic_fetch_max_relaxed(*meterIt++, f);
+    }
+    pTask->ResetMeterInfo();
+  }
+
+  m_Scheduler.Reset();
+}
+
+void GOSoundOrganEngine::WakeupThreads() {
+  for (auto &pThread : mp_threads)
+    pThread->Wakeup();
+}
+
+/*
+ * Organ interface implementation (from GOSoundOrganInterface)
+ */
+
+unsigned GOSoundOrganEngine::SamplesDiffToMs(
+  uint64_t fromSamples, uint64_t toSamples) const {
+  return (unsigned)std::min(
+    (toSamples - fromSamples) * 1000 / m_SampleRate, (uint64_t)UINT_MAX);
 }
 
 float GOSoundOrganEngine::GetRandomFactor() const {
-  if (m_RandomizeSpeaking) {
+  float result = 1;
+
+  if (m_IsRandomizeSpeaking) {
     const double factor = (pow(2, 1.0 / 1200.0) - 1) / (RAND_MAX / 2);
     int num = rand() - RAND_MAX / 2;
-    return 1 + num * factor;
+
+    result = 1 + num * factor;
   }
-  return 1;
+  return result;
 }
 
 void GOSoundOrganEngine::PassSampler(GOSoundSampler *sampler) {
   int taskId = sampler->m_SamplerTaskId;
 
   if (isWindchestTask(taskId))
-    m_AudioGroupTasks[sampler->m_AudioGroupId]->Add(sampler);
+    mp_AudioGroupTasks[sampler->m_AudioGroupId]->Add(sampler);
   else
-    m_TremulantTasks[tremulantTaskToIndex(taskId)]->Add(sampler);
+    mp_TremulantTasks[tremulantTaskToIndex(taskId)]->Add(sampler);
 }
 
 void GOSoundOrganEngine::StartSampler(GOSoundSampler *sampler) {
@@ -279,7 +491,7 @@ void GOSoundOrganEngine::StartSampler(GOSoundSampler *sampler) {
   sampler->stop = 0;
   sampler->new_attack = 0;
   sampler->p_WindchestTask = isWindchestTask(taskId)
-    ? m_WindchestTasks[windchestTaskToIndex(taskId)]
+    ? mp_WindchestTasks[windchestTaskToIndex(taskId)].get()
     : nullptr;
   PassSampler(sampler);
 }
@@ -294,7 +506,7 @@ bool GOSoundOrganEngine::ProcessSampler(
 
   if (process_sampler) {
     if (sampler->is_release &&
-        ((m_PolyphonyLimiting &&
+        ((m_IsPolyphonyLimiting &&
           m_SamplerPool.UsedSamplerCount() >= m_PolyphonySoftLimit &&
           m_CurrentTime - sampler->time > 172 * 16) ||
          sampler->drop_counter > 1))
@@ -325,7 +537,7 @@ bool GOSoundOrganEngine::ProcessSampler(
     if (
       (sampler->stop && sampler->stop <= m_CurrentTime)
       || (sampler->new_attack && sampler->new_attack <= m_CurrentTime)) {
-      m_ReleaseProcessor->Add(sampler);
+      mp_ReleaseTask->Add(sampler);
       return false;
     }
   }
@@ -352,77 +564,6 @@ void GOSoundOrganEngine::ProcessRelease(GOSoundSampler *sampler) {
 
 void GOSoundOrganEngine::ReturnSampler(GOSoundSampler *sampler) {
   m_SamplerPool.ReturnSampler(sampler);
-}
-
-unsigned GOSoundOrganEngine::GetBufferSizeFor(
-  unsigned outputIndex, unsigned nFrames) const {
-  return sizeof(float) * nFrames
-    * m_AudioOutputTasks[outputIndex + 1]->GetNChannels();
-}
-
-void GOSoundOrganEngine::GetAudioOutput(
-  unsigned outputIndex, bool isLast, GOSoundBufferMutable &outBuffer) {
-  if (m_HasBeenSetup.load()) {
-    GOSoundOutputTask *pOutputTask = m_AudioOutputTasks[outputIndex + 1];
-
-    pOutputTask->Finish(isLast);
-    outBuffer.CopyFrom(*pOutputTask);
-  } else
-    outBuffer.FillWithSilence();
-}
-
-/**
- * Atomically updates maxValue to max(maxValue, value) with relaxed ordering.
- * std::atomic<T>::fetch_max is only available in C++26.
- */
-template <typename T>
-static void atomic_fetch_max_relaxed(std::atomic<T> &maxValue, T value) {
-  T oldMax = maxValue.load(std::memory_order_relaxed);
-
-  while (oldMax < value
-         && !maxValue.compare_exchange_weak(
-           oldMax, value, std::memory_order_relaxed))
-    ;
-}
-
-void GOSoundOrganEngine::NextPeriod() {
-  m_Scheduler.Exec();
-
-  m_CurrentTime += m_SamplesPerBuffer;
-  atomic_fetch_max_relaxed(m_UsedPolyphony, m_SamplerPool.UsedSamplerCount());
-
-  // Audio thread: load with acquire so that the new vector written by
-  // SetAudioOutput() (store with release) is visible after a Stop/Start cycle.
-  // Values accumulate between GUI polls; GetMeterInfo() resets via exchange(0).
-  std::vector<std::atomic<float>> *const pMeterInfo
-    = p_MeterInfo.load(std::memory_order_acquire);
-  const std::atomic<float> *const pMeterEnd
-    = pMeterInfo->data() + pMeterInfo->size();
-  std::atomic<float> *pMeter = pMeterInfo->data();
-
-  // task[0] is the downmix/recorder task; its channels have never been part of
-  // the meter display. mp_MeterInfo holds exactly the real output channels from
-  // tasks[1..N]. GOFrame::OnMeters guards against size mismatches with
-  // vals.size() == m_VolumeGauge.size() + 1, so a temporary count change
-  // (e.g. during Stop/Start) safely skips one GUI tick rather than crashing.
-  for (unsigned i = 1; i < m_AudioOutputTasks.size(); i++) {
-    GOSoundOutputTask *const pTask = m_AudioOutputTasks[i];
-
-    assert(pTask);
-    for (const float f : pTask->GetMeterInfo()) {
-      assert(pMeter < pMeterEnd);
-      atomic_fetch_max_relaxed(*(pMeter++), f);
-    }
-    pTask->ResetMeterInfo();
-  }
-
-  m_Scheduler.Reset();
-}
-
-unsigned GOSoundOrganEngine::SamplesDiffToMs(
-  uint64_t fromSamples, uint64_t toSamples) const {
-  return (unsigned)std::min(
-    (toSamples - fromSamples) * 1000 / m_SampleRate, (uint64_t)UINT_MAX);
 }
 
 GOSoundSampler *GOSoundOrganEngine::CreateTaskSample(
@@ -455,7 +596,7 @@ GOSoundSampler *GOSoundOrganEngine::CreateTaskSample(
       sampler->stream.InitStream(
         &m_resample,
         section,
-        m_interpolation,
+        m_InterpolationType,
         GetRandomFactor() * pSoundProvider->GetTuning() / (float)m_SampleRate);
 
       const float playback_gain
@@ -502,7 +643,7 @@ void GOSoundOrganEngine::SwitchToAnotherAttack(GOSoundSampler *pSampler) {
         // start new section stream in the old sampler
         pSampler->m_WaveTremulantStateFor = section->GetWaveTremulantStateFor();
         pSampler->stream.InitAlignedStream(
-          section, m_interpolation, &new_sampler->stream);
+          section, m_InterpolationType, &new_sampler->stream);
         pSampler->p_SoundProvider = pProvider;
         pSampler->time = m_CurrentTime + 1;
 
@@ -525,7 +666,7 @@ void GOSoundOrganEngine::CreateReleaseSampler(GOSoundSampler *handle) {
   if (!handle->p_SoundProvider)
     return;
 
-  /* The beloow code creates a new sampler to playback the release, the
+  /* The below code creates a new sampler to playback the release, the
    * following code takes the active sampler for this pipe (which will be
    * in either the attack or loop section) and sets the fadeout property
    * which will decay this portion of the pipe. The sampler will
@@ -544,7 +685,7 @@ void GOSoundOrganEngine::CreateReleaseSampler(GOSoundSampler *handle) {
 
   int taskId = handle->m_SamplerTaskId;
   float vol = isWindchestTask(taskId)
-    ? m_WindchestTasks[windchestTaskToIndex(taskId)]->GetWindchestVolume()
+    ? mp_WindchestTasks[windchestTaskToIndex(taskId)]->GetWindchestVolume()
     : 1.0f;
 
   // FIXME: this is wrong... the intention is to not create a release for a
@@ -552,6 +693,7 @@ void GOSoundOrganEngine::CreateReleaseSampler(GOSoundSampler *handle) {
   // against a double. We should test against a minimum level.
   if (vol && release_section) {
     GOSoundSampler *new_sampler = m_SamplerPool.GetSampler();
+
     if (new_sampler != NULL) {
       new_sampler->p_SoundProvider = this_pipe;
       new_sampler->time = m_CurrentTime + 1;
@@ -569,7 +711,7 @@ void GOSoundOrganEngine::CreateReleaseSampler(GOSoundSampler *handle) {
          * volume on the detached chest will not match the volume on
          * the existing chest. */
         gain_target *= vol;
-        if (m_ScaledReleases) {
+        if (m_IsScaledReleases) {
           /* Note: "time" is in milliseconds. */
           int time = ((m_CurrentTime - handle->time) * 1000) / m_SampleRate;
           /* TODO: below code should be replaced by a more accurate model of the
@@ -639,15 +781,15 @@ void GOSoundOrganEngine::CreateReleaseSampler(GOSoundSampler *handle) {
           MsToSamples(gain_decay_length));
 
       if (
-        m_ReleaseAlignmentEnabled
+        m_IsReleaseAlignmentEnabled
         && release_section->SupportsStreamAlignment()) {
         new_sampler->stream.InitAlignedStream(
-          release_section, m_interpolation, &handle->stream);
+          release_section, m_InterpolationType, &handle->stream);
       } else {
         new_sampler->stream.InitStream(
           &m_resample,
           release_section,
-          m_interpolation,
+          m_InterpolationType,
           this_pipe->GetTuning() / (float)m_SampleRate);
       }
       new_sampler->is_release = true;
@@ -700,100 +842,6 @@ void GOSoundOrganEngine::SwitchSample(
   handle->new_attack = m_CurrentTime + handle->delay;
 }
 
-void GOSoundOrganEngine::StartThreads(unsigned nConcurrency) {
-  GOMutexLocker thread_locker(m_ThreadLock);
-
-  for (unsigned i = 0; i < nConcurrency; i++)
-    mp_threads.push_back(std::make_unique<GOSoundThread>(&m_Scheduler));
-
-  for (auto &pThread : mp_threads)
-    pThread->Run();
-}
-
-void GOSoundOrganEngine::StopThreads() {
-  for (auto &pThread : mp_threads)
-    pThread->Delete();
-
-  GOMutexLocker thread_locker(m_ThreadLock);
-
-  mp_threads.clear();
-}
-
-void GOSoundOrganEngine::BuildAndStart(
-  GOConfig &config,
-  unsigned sampleRate,
-  unsigned samplesPerBuffer,
-  GOOrganModel &organModel,
-  GOMemoryPool &memoryPool,
-  unsigned releaseConcurrency,
-  GOSoundRecorder &audioRecorder) {
-  const unsigned audio_group_count = config.GetAudioGroups().size();
-  std::vector<GOAudioDeviceConfig> &audio_config
-    = config.GetAudioDeviceConfig();
-  const unsigned audioDeviceCount = audio_config.size();
-  std::vector<GOAudioOutputConfiguration> engine_config;
-
-  engine_config.resize(audioDeviceCount);
-  for (unsigned deviceI = 0; deviceI < audioDeviceCount; deviceI++) {
-    const GOAudioDeviceConfig &deviceConfig = audio_config[deviceI];
-    const auto &deviceOutputs = deviceConfig.GetChannelOututs();
-    GOAudioOutputConfiguration &engineConfig = engine_config[deviceI];
-
-    engineConfig.channels = deviceConfig.GetChannels();
-    engineConfig.scale_factors.resize(engineConfig.channels);
-    for (unsigned channelI = 0; channelI < engineConfig.channels; channelI++) {
-      std::vector<float> &scaleFactors = engineConfig.scale_factors[channelI];
-
-      scaleFactors.resize(audio_group_count * 2);
-      std::fill(
-        scaleFactors.begin(),
-        scaleFactors.end(),
-        GOAudioDeviceConfig::MUTE_VOLUME);
-
-      if (channelI < deviceOutputs.size()) {
-        for (const auto &groupOutput : deviceOutputs[channelI]) {
-          int id = config.GetStrictAudioGroupId(groupOutput.GetName());
-
-          if (id >= 0) {
-            scaleFactors[id * 2] = groupOutput.GetLeft();
-            scaleFactors[id * 2 + 1] = groupOutput.GetRight();
-          }
-        }
-      }
-    }
-  }
-
-  SetSamplesPerBuffer(samplesPerBuffer);
-  SetPolyphonyLimiting(config.ManagePolyphony());
-  SetHardPolyphony(config.PolyphonyLimit());
-  SetScaledReleases(config.ScaleRelease());
-  SetRandomizeSpeaking(config.RandomizeSpeaking());
-  SetInterpolationType(config.m_InterpolationType());
-  SetAudioGroupCount(audio_group_count);
-  SetSampleRate(sampleRate);
-  SetAudioOutput(engine_config);
-  SetupReverb(config);
-  SetAudioRecorder(&audioRecorder, config.RecordDownmix());
-  Setup(organModel, memoryPool, releaseConcurrency);
-  StartThreads(config.Concurrency());
-  m_Scheduler.ResumeGivingWork();
-}
-
-void GOSoundOrganEngine::StopAndDestroy() {
-  m_Scheduler.PauseGivingWork();
-  for (auto &pThread : mp_threads)
-    pThread->WaitForIdle();
-  StopThreads();
-  ClearSetup();
-}
-
-void GOSoundOrganEngine::WakeupThreads() {
-  GOMutexLocker thread_locker(m_ThreadLock);
-
-  for (auto &pThread : mp_threads)
-    pThread->Wakeup();
-}
-
 void GOSoundOrganEngine::UpdateVelocity(
   const GOSoundProvider *pipe, GOSoundSampler *handle, unsigned velocity) {
   assert(handle);
@@ -808,4 +856,31 @@ void GOSoundOrganEngine::UpdateVelocity(
     handle->velocity = velocity;
     handle->fader.SetVelocityVolume(pipe->GetVelocityVolume(velocity));
   }
+}
+
+/*
+ * Other functions
+ */
+
+std::vector<float> GOSoundOrganEngine::GetMeterInfo() {
+  // GUI thread: m_LifecycleMutex prevents concurrent BuildEngine/DestroyEngine
+  // from modifying m_MeterInfo while we read it.
+  GOMutexLocker locker(m_LifecycleMutex);
+
+  // result[0] = polyphony ratio; result[1..] = per-channel peak levels.
+  // When not working, m_MeterInfo may be empty; result contains only zeros.
+  std::vector<float> result(m_MeterInfo.size() + 1, 0.0f);
+
+  if (IsWorking()) {
+    const unsigned hardPolyphony = GetHardPolyphony();
+    float *pResult = result.data();
+
+    assert(hardPolyphony > 0);
+    // exchange(0) reads accumulated max and resets it for the next poll
+    *(pResult++)
+      = m_UsedPolyphony.exchange(0) / static_cast<float>(hardPolyphony);
+    for (std::atomic<float> &v : m_MeterInfo)
+      *(pResult++) = v.exchange(0.0f);
+  }
+  return result;
 }

--- a/src/grandorgue/sound/GOSoundOrganEngine.h
+++ b/src/grandorgue/sound/GOSoundOrganEngine.h
@@ -17,6 +17,7 @@
 #include "playing/GOSoundResample.h"
 #include "playing/GOSoundSampler.h"
 #include "playing/GOSoundSamplerPool.h"
+#include "reverb/GOSoundReverb.h"
 #include "scheduler/GOSoundScheduler.h"
 
 #include "GOSoundOrganInterface.h"
@@ -25,109 +26,204 @@ class GOConfig;
 class GOMemoryPool;
 class GOOrganModel;
 class GOSoundBufferMutable;
-class GOSoundProvider;
-class GOSoundRecorder;
 class GOSoundGroupTask;
 class GOSoundOutputTask;
+class GOSoundProvider;
+class GOSoundRecorder;
 class GOSoundReleaseTask;
+class GOSoundTask;
 class GOSoundThread;
 class GOSoundTouchTask;
 class GOSoundTremulantTask;
 class GOSoundWindchestTask;
-class GOSoundTask;
 class GOWindchest;
 
-typedef struct {
-  unsigned channels;
-  std::vector<std::vector<float>> scale_factors;
-} GOAudioOutputConfiguration;
-
 /**
- * This class represents a sound engine of one loaded organ. It reflects some
- * GrandOrgue-wide objects (AudioGroup) and some objects of it's model
- * (WindChests, Tremulants)
+ * @brief Sound engine for one loaded organ.
+ *
+ * Lifecycle (steps 3-4 are repeatable for restart with new parameters):
+ *
+ *   1. Constructor: GOSoundOrganEngine(organModel, memoryPool)
+ *   2. Configuration: SetFromConfig(config) or manual setters
+ *   3. BuildAndStart(audioOutputConfigs, nSamplesPerBuffer, sampleRate,
+ * recorder) — builds tasks and starts the engine
+ *      ... GetAudioOutput() is called from the audio thread ...
+ *   4. StopAndDestroy() — stops the engine and destroys tasks
  */
-
 class GOSoundOrganEngine : public GOSoundOrganInterface {
+public:
+  /*
+   * Nested type
+   */
+
+  /**
+   * @brief Configuration for one audio output device.
+   *
+   * scaleFactors[ch][groupI*2+ch] = 0.0f means direct output of group groupI
+   * into channel ch. Other values = GOAudioDeviceConfig::MUTE_VOLUME (-121.0f).
+   */
+  struct AudioOutputConfig {
+    unsigned channels;
+    std::vector<std::vector<float>> scaleFactors;
+  };
+
+  /*
+   * Factory functions
+   */
+
+  /**
+   * @brief Creates output configurations from GOConfig.
+   */
+  static std::vector<AudioOutputConfig> createAudioOutputConfigs(
+    GOConfig &config, unsigned nAudioGroups);
+
+  /**
+   * @brief Creates a single stereo output for nAudioGroups groups.
+   *
+   * For each group i:
+   *   scaleFactors[0][i*2] = 0.0f (L),
+   *   scaleFactors[0][i*2+1] = MUTE_VOLUME (-121.0f) (R)
+   *   scaleFactors[1][i*2] = MUTE_VOLUME (-121.0f) (L)
+   *   scaleFactors[1][i*2+1] = 0.0f (R)
+   */
+  static std::vector<AudioOutputConfig> createDefaultOutputConfigs(
+    unsigned nAudioGroups = 1);
+
 private:
   static constexpr int DETACHED_RELEASE_TASK_ID = 0;
 
+  /*
+   * Constructor constants: objects that live for the entire instance lifetime
+   */
+
+  GOOrganModel &r_OrganModel;
+  GOMemoryPool &r_MemoryPool;
+  // mp_ReleaseTask references mp_AudioGroupTasks [B1]; created in constructor,
+  // added to m_Scheduler in BuildEngine [B8]
+  std::unique_ptr<GOSoundReleaseTask> mp_ReleaseTask;
+  // mp_TouchTask references r_MemoryPool; created in constructor,
+  // added to m_Scheduler in BuildEngine [B8]
+  std::unique_ptr<GOSoundTouchTask> mp_TouchTask;
+  GOSoundResample m_resample;
+
+  /*
+   * Configuration parameters
+   */
+
+  unsigned m_NAudioGroups;
+  unsigned m_NAuxThreads;
+  bool m_IsDownmix;
+  unsigned m_NReleaseRepeats;
+  bool m_IsPolyphonyLimiting;
   unsigned m_PolyphonySoftLimit;
-  bool m_PolyphonyLimiting;
-  bool m_ScaledReleases;
-  bool m_ReleaseAlignmentEnabled;
-  bool m_RandomizeSpeaking;
-  int m_Volume;
-  unsigned m_SamplesPerBuffer;
-  float m_Gain;
+  bool m_IsScaledReleases;
+  bool m_IsReleaseAlignmentEnabled;
+  bool m_IsRandomizeSpeaking;
+  // TODO: rename to m_gain (stores gain in dB; in GrandOrgue "gain" means dB)
+  int m_volume;
+  // TODO: rename to m_amplitude (stores the linear amplitude coefficient
+  // derived
+  //       from m_volume; in GrandOrgue "amplitude" means a linear coefficient)
+  float m_gain;
+  GOSoundResample::InterpolationType m_InterpolationType;
+  GOSoundReverb::ReverbConfig m_ReverbConfig;
+
+  /*
+   * Start parameters (set from BuildAndStart arguments)
+   */
+
+  unsigned m_NSamplesPerBuffer;
   unsigned m_SampleRate;
 
-  // time in samples
+  /*
+   * Lifecycle state
+   */
+
+  enum class LifecycleState { IDLE, BUILT, WORKING, USED };
+
+  // Protects the IDLE↔BUILT transition (BuildEngine / DestroyEngine).
+  // Any function that must guarantee the lifecycle state does not change
+  // during its execution (e.g. GetMeterInfo) must acquire this mutex before
+  // reading m_LifecycleState.
+  GOMutex m_LifecycleMutex;
+
+  std::atomic<LifecycleState> m_LifecycleState;
+
+  /*
+   * Tasks built in BuildEngine (in build order [B1]-[B11])
+   */
+
+  // [B1] mp_AudioGroupTasks: created per audio group (m_NAudioGroups entries)
+  //   — referenced by: mp_ReleaseTask (constructor), mp_AudioOutputTasks [B2]
+  ptr_vector<GOSoundGroupTask> mp_AudioGroupTasks;
+  // [B2] mp_AudioOutputTasks: created from audioOutputConfigs (per-device
+  // tasks)
+  //   — uses mp_AudioGroupTasks [B1] via SetOutputs()
+  //   — referenced by: m_MeterInfo [B3], p_AudioRecorder [B5], reverb [B6]
+  std::vector<std::unique_ptr<GOSoundOutputTask>> mp_AudioOutputTasks;
+  // [B3] m_MeterInfo: per-channel peak levels for the meter display
+  //   — uses nTotalChannels accumulated over mp_AudioOutputTasks [B2]
+  //   — audio thread: NextPeriod() writes via atomic_fetch_max_relaxed()
+  //   — GUI thread: GetMeterInfo() reads and resets under m_LifecycleMutex
+  std::vector<std::atomic<float>> m_MeterInfo;
+  // [B4] mp_DownmixTask: optional stereo downmix task (only when m_IsDownmix)
+  //   — uses mp_AudioGroupTasks [B1] via SetOutputs()
+  //   — referenced by: p_AudioRecorder [B5], reverb setup [B6]
+  std::unique_ptr<GOSoundOutputTask> mp_DownmixTask;
+  // [B5] p_AudioRecorder: non-owning pointer to the recorder passed in
+  //   — uses mp_DownmixTask [B4] or mp_AudioOutputTasks [B2]
+  GOSoundRecorder *p_AudioRecorder;
+  // [B6] reverb: set up inline on mp_DownmixTask [B4] and mp_AudioOutputTasks
+  // [B2]
+  //   — uses m_ReverbConfig, m_SampleRate, m_NSamplesPerBuffer
+  //
+  // [B7] mp_TremulantTasks: one per tremulant in r_OrganModel
+  //   — referenced by mp_WindchestTasks after [B9] Init()
+  ptr_vector<GOSoundTremulantTask> mp_TremulantTasks;
+  // [B8] mp_WindchestTasks: one special + one per windchest in r_OrganModel
+  //   — initialized in [B9] with mp_TremulantTasks [B7]
+  std::vector<std::unique_ptr<GOSoundWindchestTask>> mp_WindchestTasks;
+  // [B9] Init(): connects mp_WindchestTasks [B8] to mp_TremulantTasks [B7]
+  //
+  // [B10] m_Scheduler: all tasks added; SetRepeatCount(m_NReleaseRepeats)
+  //   — uses all tasks above + mp_ReleaseTask + mp_TouchTask (constructor)
+  GOSoundScheduler m_Scheduler;
+  // [B11] mp_threads: worker threads created via BuildThreads(m_NAuxThreads)
+  //   — uses m_Scheduler [B10]
+  std::vector<std::unique_ptr<GOSoundThread>> mp_threads;
+
+  /*
+   * Counters
+   */
+
   uint64_t m_CurrentTime;
   GOSoundSamplerPool m_SamplerPool;
-  unsigned m_AudioGroupCount;
   std::atomic_uint m_UsedPolyphony;
 
-  // protects mp_MeterInfo/p_MeterInfo against concurrent replacement
-  // (SetAudioOutput vs GetMeterInfo)
-  GOMutex m_MeterMutex;
+  /*
+   * Private lifecycle functions (callee first)
+   */
 
-  // Per-channel peak levels for the meter display (one element per real output
-  // channel; polyphony is tracked separately in m_UsedPolyphony).
-  //
-  // Ownership and access pattern:
-  //   Audio thread   — p_MeterInfo.load(acquire) each period; writes peaks via
-  //                    atomic_fetch_max_relaxed(); no mutex held
-  //   GUI thread     — GetMeterInfo() under m_MeterMutex; reads *p_MeterInfo,
-  //                    resets elements via exchange(0); prepends polyphony
-  //                    ratio from m_UsedPolyphony.exchange(0)
-  //   Control thread — SetAudioOutput() under m_MeterMutex; creates a new
-  //                    vector when channel count changes, stores pointer via
-  //                    p_MeterInfo.store(release)
-  //
-  // mp_MeterInfo owns the vector; p_MeterInfo is an atomic pointer to the
-  // same object (always == mp_MeterInfo.get()). SetAudioOutput() always
-  // allocates a new vector, so size and data pointer are always consistent
-  // within a single vector object published atomically via p_MeterInfo.
-  // std::shared_ptr with atomic access would provide automatic lifetime safety
-  // but incurs atomic reference-count increments/decrements on every
-  // NextPeriod() call (~100/s), adding unnecessary overhead in the audio
-  // thread. float is used instead of double because std::atomic<float> is
-  // lock-free on all supported platforms (x86, ARM), while std::atomic<double>
-  // is not.
-  std::unique_ptr<std::vector<std::atomic<float>>> mp_MeterInfo;
-  // always == mp_MeterInfo.get()
-  std::atomic<std::vector<std::atomic<float>> *> p_MeterInfo;
+  void BuildEngine(
+    const std::vector<AudioOutputConfig> &audioOutputConfigs,
+    unsigned nSamplesPerBuffer,
+    unsigned sampleRate,
+    GOSoundRecorder &recorder);
+  void DestroyEngine();
 
-  ptr_vector<GOSoundTremulantTask> m_TremulantTasks;
-  ptr_vector<GOSoundWindchestTask> m_WindchestTasks;
-  ptr_vector<GOSoundGroupTask> m_AudioGroupTasks;
-  ptr_vector<GOSoundOutputTask> m_AudioOutputTasks;
-  GOSoundRecorder *m_AudioRecorder;
-  GOSoundReleaseTask *m_ReleaseProcessor;
-  std::unique_ptr<GOSoundTouchTask> m_TouchTask;
-  GOSoundScheduler m_Scheduler;
+  void ResetCounters();
 
-  std::vector<std::unique_ptr<GOSoundThread>> mp_threads;
-  GOMutex m_ThreadLock;
+  void StartEngine();
+  void StopEngine();
 
-  GOSoundResample m_resample;
-  GOSoundResample::InterpolationType m_interpolation;
-
-  std::atomic_bool m_HasBeenSetup;
-
-  void StartThreads(unsigned nConcurrency);
-  void StopThreads();
+  /*
+   * Other private functions
+   */
 
   unsigned MsToSamples(unsigned ms) const { return m_SampleRate * ms / 1000; }
 
   unsigned SamplesDiffToMs(uint64_t fromSamples, uint64_t toSamples) const;
 
-  /* samplerTaskId:
-     -1 .. -n Tremulants
-     0 (DETACHED_RELEASE_TASK_ID) detached release
-     1 .. n Windchests
-  */
   inline static unsigned isWindchestTask(int taskId) { return taskId >= 0; }
 
   inline static unsigned windchestTaskToIndex(int taskId) {
@@ -149,63 +245,162 @@ private:
     uint64_t prevEventTime,
     bool isRelease,
     uint64_t *pStartTimeSamples);
+
   void CreateReleaseSampler(GOSoundSampler *sampler);
 
   /**
    * Creates a new sampler with decay of current loop.
-   * Switch this sampler to the new attack.
-   * It is used when a wave tremulant is switched on or off.
+   * Switches this sampler to the new attack.
+   * Used when a wave tremulant is switched on or off.
    * @param pSampler current playing sampler for switching to a new attack
    */
   void SwitchToAnotherAttack(GOSoundSampler *pSampler);
+
   float GetRandomFactor() const;
-  unsigned GetBufferSizeFor(unsigned outputIndex, unsigned n_frames) const;
 
 public:
-  GOSoundOrganEngine();
+  /*
+   * Constructors and destructors
+   */
+
+  GOSoundOrganEngine(GOOrganModel &organModel, GOMemoryPool &memoryPool);
+  // Defined in the .cpp file because the destructor of std::unique_ptr requires
+  // the complete type of the managed object, which is only forward-declared
+  // here.
   ~GOSoundOrganEngine();
 
-  // Group 1: Independent setters (no call-order dependencies)
-  unsigned GetSampleRate() const override { return m_SampleRate; }
-  void SetSampleRate(unsigned sample_rate) { m_SampleRate = sample_rate; }
-  void SetSamplesPerBuffer(unsigned sample_per_buffer) {
-    m_SamplesPerBuffer = sample_per_buffer;
+  /*
+   * Configuration getters and setters
+   */
+
+  unsigned GetNAudioGroups() const { return m_NAudioGroups; }
+  void SetNAudioGroups(unsigned nAudioGroups) { m_NAudioGroups = nAudioGroups; }
+
+  unsigned GetNAuxThreads() const { return m_NAuxThreads; }
+  void SetNAuxThreads(unsigned nAuxThreads) { m_NAuxThreads = nAuxThreads; }
+
+  bool IsDownmix() const { return m_IsDownmix; }
+  void SetDownmix(bool isDownmix) { m_IsDownmix = isDownmix; }
+
+  unsigned GetNReleaseRepeats() const { return m_NReleaseRepeats; }
+  void SetNReleaseRepeats(unsigned nReleaseRepeats) {
+    m_NReleaseRepeats = nReleaseRepeats;
   }
-  int GetVolume() const { return m_Volume; }
+
+  bool IsReleaseAlignmentEnabled() const { return m_IsReleaseAlignmentEnabled; }
+  void SetReleaseAlignmentEnabled(bool isEnabled) {
+    m_IsReleaseAlignmentEnabled = isEnabled;
+  }
+
+  const GOSoundReverb::ReverbConfig &GetReverbConfig() const {
+    return m_ReverbConfig;
+  }
+  void SetReverbConfig(const GOSoundReverb::ReverbConfig &config) {
+    m_ReverbConfig = config;
+  }
+
+  // TODO: rename to GetAmplitude() (returns linear amplitude coefficient)
+  float GetGain() const { return m_gain; }
+
+  // TODO: rename to GetGain() (returns gain in dB)
+  int GetVolume() const { return m_volume; }
+  // TODO: rename to SetGain(int gain)
   void SetVolume(int volume);
+
   unsigned GetHardPolyphony() const { return m_SamplerPool.GetUsageLimit(); }
   void SetHardPolyphony(unsigned polyphony);
-  void SetPolyphonyLimiting(bool limiting) { m_PolyphonyLimiting = limiting; }
-  void SetScaledReleases(bool enable) { m_ScaledReleases = enable; }
-  void SetRandomizeSpeaking(bool enable) { m_RandomizeSpeaking = enable; }
-  void SetInterpolationType(unsigned type) {
-    m_interpolation = (GOSoundResample::InterpolationType)type;
+
+  bool IsPolyphonyLimiting() const { return m_IsPolyphonyLimiting; }
+  void SetPolyphonyLimiting(bool isLimiting) {
+    m_IsPolyphonyLimiting = isLimiting;
   }
 
-  // Group 2: Dependent setters (must be called in this order)
-  // Must be called after SetSamplesPerBuffer because uses m_SamplesPerBuffer
-  unsigned GetAudioGroupCount() const { return m_AudioGroupCount; }
-  void SetAudioGroupCount(unsigned groups);
-  // Must be called after SetAudioGroupCount because uses m_AudioGroupCount and
-  // m_SamplesPerBuffer
-  void SetAudioOutput(std::vector<GOAudioOutputConfiguration> audio_outputs);
-  // Must be called after SetAudioOutput because iterates m_AudioOutputTasks
-  void SetupReverb(GOConfig &settings);
-  // Must be called after SetAudioOutput because uses m_AudioOutputTasks
-  void SetAudioRecorder(GOSoundRecorder *recorder, bool downmix);
+  bool IsScaledReleases() const { return m_IsScaledReleases; }
+  void SetScaledReleases(bool isEnabled) { m_IsScaledReleases = isEnabled; }
 
-  // Group 3: Other getters
-  float GetGain() const { return m_Gain; }
+  bool IsRandomizeSpeaking() const { return m_IsRandomizeSpeaking; }
+  void SetRandomizeSpeaking(bool isEnabled) {
+    m_IsRandomizeSpeaking = isEnabled;
+  }
+
+  GOSoundResample::InterpolationType GetInterpolationType() const {
+    return m_InterpolationType;
+  }
+  void SetInterpolationType(unsigned type) {
+    m_InterpolationType = (GOSoundResample::InterpolationType)type;
+  }
+
+  /** Reads parameters from GOConfig and stores them via setters. */
+  void SetFromConfig(GOConfig &config);
+
+  /*
+   * Start parameter getters (values come via BuildAndStart)
+   */
+
+  unsigned GetSampleRate() const override { return m_SampleRate; }
+  unsigned GetNSamplesPerBuffer() const { return m_NSamplesPerBuffer; }
+
+  /*
+   * Other getters
+   */
+
   uint64_t GetTime() const { return m_CurrentTime; }
   std::vector<float> GetMeterInfo();
   GOSoundScheduler &GetScheduler() { return m_Scheduler; }
 
-  void Reset();
-  void Setup(
-    GOOrganModel &organModel,
-    GOMemoryPool &memoryPool,
-    unsigned releaseCount = 1);
-  void ClearSetup();
+  /*
+   * Lifecycle state
+   */
+
+  /** true if the engine is in the initial state (before BuildAndStart or after
+   * StopAndDestroy). */
+  bool IsIdle() const {
+    return m_LifecycleState.load() == LifecycleState::IDLE;
+  }
+
+  /** true if the engine is running (WORKING or USED). */
+  bool IsWorking() const {
+    return m_LifecycleState.load() >= LifecycleState::WORKING;
+  }
+
+  /** true if the engine is connected to the audio system. */
+  bool IsUsed() const {
+    return m_LifecycleState.load() >= LifecycleState::USED;
+  }
+
+  /** Switches between WORKING and USED; called from GOSoundSystem. */
+  void SetUsed(bool isUsed);
+
+  /*
+   * Public lifecycle functions
+   */
+
+  /**
+   * @brief Creates tasks and starts the engine.
+   *
+   * Call after SetFromConfig() or manual setters.
+   * After return the engine is ready to receive GetAudioOutput() calls.
+   * @param audioOutputConfigs  Output configurations; must not be empty.
+   * @param nSamplesPerBuffer   Buffer size in samples (from audio system).
+   * @param sampleRate          Sample rate in Hz (from audio system).
+   * @param recorder            Recorder (non-owning).
+   */
+  void BuildAndStart(
+    const std::vector<AudioOutputConfig> &audioOutputConfigs,
+    unsigned nSamplesPerBuffer,
+    unsigned sampleRate,
+    GOSoundRecorder &recorder);
+
+  /**
+   * @brief Stops the engine and destroys tasks.
+   *
+   * Call after the audio system has disconnected from the engine.
+   */
+  void StopAndDestroy();
+
+  /*
+   * Organ interface (from GOSoundOrganInterface)
+   */
 
   GOSoundSampler *StartPipeSample(
     const GOSoundProvider *pipeProvider,
@@ -244,25 +439,16 @@ public:
     GOSoundSampler *handle,
     unsigned velocity) override;
 
-  /** Configure the engine for the given organ and start worker threads */
-  void BuildAndStart(
-    GOConfig &config,
-    unsigned sampleRate,
-    unsigned samplesPerBuffer,
-    GOOrganModel &organModel,
-    GOMemoryPool &memoryPool,
-    unsigned releaseConcurrency,
-    GOSoundRecorder &audioRecorder);
-
-  /** Stop worker threads and tear down the organ setup */
-  void StopAndDestroy();
-
-  /** Wake up all worker threads. Called from the audio callback. */
-  void WakeupThreads();
+  /*
+   * Functions called from GOSoundSystem
+   */
 
   void GetAudioOutput(
     unsigned outputIndex, bool isLast, GOSoundBufferMutable &outBuffer);
   void NextPeriod();
+
+  /** Wake up all worker threads. Called from the audio callback. */
+  void WakeupThreads();
 
   bool ProcessSampler(
     float *buffer, GOSoundSampler *sampler, unsigned n_frames, float volume);

--- a/src/grandorgue/sound/GOSoundSystem.cpp
+++ b/src/grandorgue/sound/GOSoundSystem.cpp
@@ -21,6 +21,7 @@
 #include "GOEvent.h"
 #include "GOOrganController.h"
 #include "GOSoundDefs.h"
+#include "GOSoundOrganEngine.h"
 
 GOSoundSystem::GOSoundSystem(GOConfig &settings)
   : m_config(settings),
@@ -187,17 +188,23 @@ void GOSoundSystem::StartStreams() {
 }
 
 void GOSoundSystem::BuildAndStartEngine() {
-  m_SoundEngine.BuildAndStart(
-    m_config,
-    m_SampleRate,
-    m_SamplesPerBuffer,
-    static_cast<GOOrganModel &>(*m_OrganController),
-    m_OrganController->GetMemoryPool(),
-    m_config.ReleaseConcurrency(),
-    m_AudioRecorder);
+  GOOrganModel &organModel = static_cast<GOOrganModel &>(*m_OrganController);
+
+  mp_SoundEngine = std::make_unique<GOSoundOrganEngine>(
+    organModel, m_OrganController->GetMemoryPool());
+  mp_SoundEngine->SetFromConfig(m_config);
+
+  auto configs = GOSoundOrganEngine::createAudioOutputConfigs(
+    m_config, mp_SoundEngine->GetNAudioGroups());
+
+  mp_SoundEngine->BuildAndStart(
+    configs, m_SamplesPerBuffer, m_SampleRate, m_AudioRecorder);
 }
 
-void GOSoundSystem::StopAndDestroyEngine() { m_SoundEngine.StopAndDestroy(); }
+void GOSoundSystem::StopAndDestroyEngine() {
+  mp_SoundEngine->StopAndDestroy();
+  mp_SoundEngine.reset();
+}
 
 bool GOSoundSystem::AssureSoundIsOpen() {
   if (!m_open) {
@@ -326,16 +333,17 @@ bool GOSoundSystem::AudioCallback(
       device.condition.Wait();
 
     unsigned cnt = m_CalcCount.fetch_add(1);
-    m_SoundEngine.GetAudioOutput(
+
+    mp_SoundEngine->GetAudioOutput(
       devIndex, cnt + 1 >= m_AudioOutputs.size(), outBuffer);
     device.wait = true;
     unsigned count = m_WaitCount.fetch_add(1);
 
     if (count + 1 == m_AudioOutputs.size()) {
-      m_SoundEngine.NextPeriod();
+      mp_SoundEngine->NextPeriod();
       UpdateMeter();
 
-      m_SoundEngine.WakeupThreads();
+      mp_SoundEngine->WakeupThreads();
       m_CalcCount.exchange(0);
       m_WaitCount.exchange(0);
 
@@ -363,9 +371,7 @@ wxString GOSoundSystem::getState() {
   if (!m_AudioOutputs.size())
     return _("No sound output occurring");
   wxString result = wxString::Format(
-    _("%d samples per buffer, %d Hz\n"),
-    m_SamplesPerBuffer,
-    m_SoundEngine.GetSampleRate());
+    _("%d samples per buffer, %d Hz\n"), m_SamplesPerBuffer, m_SampleRate);
   for (unsigned i = 0; i < m_AudioOutputs.size(); i++)
     result = result + _("\n") + m_AudioOutputs[i].port->getPortState();
   return result;

--- a/src/grandorgue/sound/GOSoundSystem.h
+++ b/src/grandorgue/sound/GOSoundSystem.h
@@ -8,6 +8,8 @@
 #ifndef GOSOUNDSYSTEM_H
 #define GOSOUNDSYSTEM_H
 
+#include <atomic>
+#include <memory>
 #include <vector>
 
 #include <wx/string.h>
@@ -68,7 +70,7 @@ private:
 
   GOMidiSystem m_midi;
   GOSoundRecorder m_AudioRecorder;
-  GOSoundOrganEngine m_SoundEngine;
+  std::unique_ptr<GOSoundOrganEngine> mp_SoundEngine;
 
   bool m_open;
   bool logSoundErrors;
@@ -132,7 +134,7 @@ public:
 
   GOConfig &GetSettings() { return m_config; }
   GOMidiSystem &GetMidi() { return m_midi; }
-  GOSoundOrganEngine &GetEngine() { return m_SoundEngine; }
+  GOSoundOrganEngine &GetEngine() { return *mp_SoundEngine; }
 
   std::vector<GOSoundDevInfo> GetAudioDevices(const GOPortsConfig &portsConfig);
   const GOSoundDevInfo &GetDefaultAudioDevice(const GOPortsConfig &portsConfig);

--- a/src/tests/GOTestExe.cpp
+++ b/src/tests/GOTestExe.cpp
@@ -61,15 +61,10 @@ int main(int argc, char *argv[]) {
   test_result_collection = GOTestCollection::Instance()->Run(categoryFilter);
 
   // Display tests results
-  int run_number_ = 0;
-  std::vector<GOTestResult *> test_results
-    = test_result_collection.get_results();
   std::cout << "==================== TESTS RESULTS ====================\n";
-  for (auto current = test_results.begin(); current != test_results.end();
-       ++current, ++run_number_) {
-    auto test_result = *current;
+  for (GOTestResult *pResult : test_result_collection.get_results()) {
     std::cout << "-------------------------------------------------------\n";
-    std::cout << test_result->GetMessage() << "\n";
+    std::cout << pResult->GetMessage() << "\n";
   }
 
   const int failed_count = GOTestCollection::Instance()->get_failed_count();

--- a/src/tests/common/GOTest.cpp
+++ b/src/tests/common/GOTest.cpp
@@ -38,16 +38,18 @@ bool GOCommonControllerTest::setUp() {
   GOTest::setUp();
   char path[] = ".";
   this->organ_directory = mkdtemp(path);
-  GOConfig settings(GetName(), "");
-  this->controller = new GOOrganController(settings);
+  mp_config.emplace(GetName(), "");
+  this->controller = new GOOrganController(*mp_config);
   this->controller->InitOrganDirectory(this->organ_directory);
   return true;
 }
 
 bool GOCommonControllerTest::tearDown() {
-  // This initialize a new GOOrganController object that will be destroyed
-  // during test teardown().
+  // Delete controller before resetting mp_config: ~GOOrganController() may
+  // still read m_config, so mp_config must outlive it.
+  delete this->controller;
   this->controller = nullptr;
+  mp_config.reset();
   unlink(this->organ_directory);
   return true;
 }

--- a/src/tests/common/GOTest.h
+++ b/src/tests/common/GOTest.h
@@ -7,8 +7,12 @@
 #ifndef GOTEST_H
 #define GOTEST_H
 
+#include <optional>
+
 #include "GOOrganController.h"
 #include "GOTestUtils.h"
+
+#include "config/GOConfig.h"
 
 class GOTest : public GOTestUtils {
   /*
@@ -36,6 +40,18 @@ public:
 };
 
 class GOCommonControllerTest : public GOTest {
+private:
+  // Owns the GOConfig that controller's GOOrganController::m_config
+  // reference points to. GOConfig has no default constructor and needs
+  // GetName(), which only resolves to the derived test's actual name once
+  // the derived constructor has run - so this is constructed in setUp(),
+  // not in the constructor's initializer list, via std::optional's
+  // deferred-construction (hence the mp_ prefix, matching this codebase's
+  // convention for members that are absent until explicitly constructed).
+  // Must outlive controller: tearDown() deletes controller before
+  // resetting mp_config (see GOTest.cpp), since ~GOOrganController() may
+  // still read m_config.
+  std::optional<GOConfig> mp_config;
 
 public:
   GOCommonControllerTest();

--- a/src/tests/testing/model/GOTestWindchest.cpp
+++ b/src/tests/testing/model/GOTestWindchest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 GrandOrgue contributors (see AUTHORS)
+ * Copyright 2023-2026 GrandOrgue contributors (see AUTHORS)
  * License GPL-2.0 or later
  * (https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
  */
@@ -45,6 +45,11 @@ void GOTestWindchest::run() {
 
   // Check enclosure volume values from midi ones
   GOEnclosure *enclosure = new GOEnclosure(*this->controller);
+  // windchest->AddEnclosure() only registers enclosure in a non-owning
+  // std::vector (GOWindchest::m_enclosure) for volume grouping; ownership
+  // (and destruction) comes from the model's own ptr_vector, registered
+  // via controller->AddEnclosure().
+  controller->AddEnclosure(enclosure);
   windchest->AddEnclosure(enclosure);
 
   enclosure->SetEnclosureValue(127);
@@ -75,6 +80,11 @@ void GOTestWindchest::run() {
   GORank *rank = new GORank(*this->controller);
   message = "The Rank count for Windchest should be 0";
   this->GOAssert(windchest->GetRankCount() == 0, message);
+  // windchest->AddRank() only registers rank in a non-owning std::vector
+  // (GOWindchest::m_ranks) for grouping; ownership (and destruction, which
+  // transitively frees rank's own owned pipes via GORank::m_Pipes) comes
+  // from the model's own ptr_vector, registered via controller->AddRank().
+  controller->AddRank(rank);
   windchest->AddRank(rank);
   this->GOAssert(windchest->GetRankCount() == 1, message);
 


### PR DESCRIPTION
## Summary
- `GOCommonControllerTest::setUp()` constructed `GOOrganController` with a `GOConfig` local to `setUp()`, leaving `controller->m_config` dangling as soon as `setUp()` returned. Any test that exercises `Load()`/`Export()`/`Save()` through `controller` would hit undefined behavior. Store the `GOConfig` as a deferred-constructed member (`mp_config`, via `std::optional` since `GOConfig` has no default constructor and needs `GetName()`, only valid once the derived test's constructor has run) that outlives `controller`.
- `tearDown()` now actually `delete`s `controller` instead of leaking it, and resets `mp_config` afterward.
- `GOTestWindchest` registered `enclosure`/`rank` only via the non-owning `GOWindchest::AddEnclosure()`/`AddRank()` instead of the owning `GOOrganController::AddEnclosure()`/`AddRank()`, leaking both (and the rank's pipe) now that `controller` is actually destroyed.

## Test plan
- [x] `GOTestExe --no-perf`: all 11 functional tests pass
- [ ] Note: a pre-existing, separate leak remains and is out of scope here — `GOOrganController::m_setter` is always `new`'d in the constructor but only registered (and thus freed) via `m_elementcreators` inside `Load()`; tests that never call `Load()` (all `GOCommonControllerTest`-based tests) leak it. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)